### PR TITLE
Update pyats and genie version to 23.5

### DIFF
--- a/pyats_genie_command_parse/version.py
+++ b/pyats_genie_command_parse/version.py
@@ -3,5 +3,5 @@ Holds the version information for the package
 """
 __copyright__ = "Copyright (c) 2020 - 2023, Benjamin P. Trachtenberg, Brett Gianpetro"
 __status__ = 'prod'
-__version_info__ = (1, 3, 6)
+__version_info__ = (1, 3, 7)
 __version__ = '.'.join(map(str, __version_info__))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyats==23.4
-genie==23.4
+pyats==23.5
+genie==23.5


### PR DESCRIPTION
Updates package versions:
- pyats from 23.4 to 23.5
- genie from 23.4 to 23.5

Release 23.5 https://github.com/CiscoTestAutomation/genieparser/pull/757
